### PR TITLE
Support ref type as generic

### DIFF
--- a/docs/docs/api.md
+++ b/docs/docs/api.md
@@ -81,7 +81,7 @@ React hook for handling form submission and validation.
 
 ## Types
 
-- `FormField<TValue, TErrorMessageKeys>` – State for a single field.
+- `FormField<TValue, TErrorMessageKeys, TRef>` – State for a single field.
 - `Form` – State for the whole form.
 - `FormFieldAtom`, `FormFieldAtomFamily`, `MultiFormField` – Atom types for fields.
 

--- a/eslint.config.js
+++ b/eslint.config.js
@@ -4,16 +4,20 @@ import tseslint from "typescript-eslint";
 
 export default tseslint.config(
   {
-    ignores: ["**/*.snap", "coverage", "lib", "node_modules", "pnpm-lock.yaml"],
+    ignores: [
+      "**/*.snap",
+      "coverage",
+      "lib",
+      "node_modules",
+      "pnpm-lock.yaml",
+      "docs",
+    ],
   },
   { linterOptions: { reportUnusedDisableDirectives: "error" } },
   eslint.configs.recommended,
+  tseslint.configs.strictTypeChecked,
+  tseslint.configs.stylisticTypeChecked,
   {
-    extends: [
-      tseslint.configs.strictTypeChecked,
-      tseslint.configs.stylisticTypeChecked,
-    ],
-    files: ["**/*.js", "**/*.ts"],
     languageOptions: {
       parserOptions: {
         projectService: { allowDefaultProject: ["*.config.*s"] },
@@ -22,12 +26,6 @@ export default tseslint.config(
     },
   },
   {
-    extends: [vitest.configs.recommended],
-    files: ["**/*.test.*"],
-    rules: { "@typescript-eslint/no-unsafe-assignment": "off" },
-  },
-  {
-    files: ["**/*.{js,mjs,cjs,ts,tsx}"],
     rules: {
       "@typescript-eslint/no-unused-vars": [
         "warn",
@@ -40,5 +38,10 @@ export default tseslint.config(
         },
       ],
     },
+  },
+  {
+    extends: [vitest.configs.recommended],
+    files: ["**/*.test.*"],
+    rules: { "@typescript-eslint/no-unsafe-assignment": "off" },
   },
 );

--- a/package.json
+++ b/package.json
@@ -21,7 +21,7 @@
   ],
   "scripts": {
     "build": "tsup",
-    "format": "prettier .",
+    "format": "prettier . --write",
     "lint": "eslint . --max-warnings 0",
     "prepare": "husky",
     "test": "vitest",

--- a/src/form.test.tsx
+++ b/src/form.test.tsx
@@ -1,7 +1,7 @@
 // @vitest-environment happy-dom
 import { describe, test, expect, vi } from "vitest";
 import { createStore, useAtom, type Atom } from "jotai";
-import { act, renderHook, waitFor } from "@testing-library/react";
+import { act, render, renderHook, waitFor } from "@testing-library/react";
 import {
   type FormFieldAtom,
   type GenericErrorMessageKeys,
@@ -12,6 +12,7 @@ import {
   internalFormStateAtom,
   createForm,
 } from "./form.js";
+import { useFormField } from "./useFormField.js";
 
 describe("formFieldAtom", () => {
   test("value should initially be set to initialValue", () => {
@@ -1009,5 +1010,61 @@ describe("compatibility of formFieldAtomFamily with Jotai atomFamily API (with a
     );
     const [{ value: newThirdValue }] = newThirdResult.current;
     expect(newThirdValue).toBe(3);
+  });
+});
+
+describe("different ref types", () => {
+  test("using a textarea with a formField", () => {
+    const { formFieldAtom } = createForm();
+
+    const atom = formFieldAtom<string, "required", HTMLTextAreaElement>({
+      initialState: "",
+      validate: (value) => {
+        if (value.length === 0) return "required";
+      },
+    });
+
+    const {
+      result: {
+        current: { ref },
+      },
+    } = renderHook(() =>
+      useFormField({
+        atom,
+      }),
+    );
+
+    render(<textarea ref={ref} />);
+
+    expect(ref.current.tagName).toBe("TEXTAREA");
+  });
+
+  test("using a textarea with a formFieldFamily", () => {
+    const { formFieldAtomFamily } = createForm();
+
+    const atomFamily = formFieldAtomFamily<
+      string,
+      string,
+      undefined,
+      HTMLTextAreaElement
+    >({
+      initialState: "",
+    });
+
+    const atomOne = atomFamily("one");
+
+    const {
+      result: {
+        current: { ref },
+      },
+    } = renderHook(() =>
+      useFormField({
+        atom: atomOne,
+      }),
+    );
+
+    render(<textarea ref={ref} />);
+
+    expect(ref.current.tagName).toBe("TEXTAREA");
   });
 });

--- a/src/form.ts
+++ b/src/form.ts
@@ -401,9 +401,9 @@ export function internalCreateForm() {
     // in this case, we do not care about the actual value of form field families, just that they are form field families
     // eslint-disable-next-line @typescript-eslint/no-explicit-any
     FormFieldAtomFamily<any, any, GenericErrorMessageKeys, any>,
-    // eslint-disable-next-line @typescript-eslint/no-explicit-any
     Map<
       PrimitiveParam,
+      // eslint-disable-next-line @typescript-eslint/no-explicit-any
       [FormFieldAtom<any, GenericErrorMessageKeys, any>, number]
     >
   >();

--- a/src/useFormField.ts
+++ b/src/useFormField.ts
@@ -20,8 +20,9 @@ import type {
 export type UseFormFieldOptions<
   TValue extends PrimitiveValue,
   TErrorMessageKeys extends GenericErrorMessageKeys,
+  TRef extends HTMLElement = HTMLInputElement,
 > = {
-  atom: FormFieldAtom<TValue, TErrorMessageKeys>;
+  atom: FormFieldAtom<TValue, TErrorMessageKeys, TRef>;
   /**
    * Add an additional onChange handler to the field.
    * @param value the current value of the field
@@ -45,11 +46,14 @@ export type UseFormFieldOptions<
   DefaultErrorMessageKeys
 >;
 
-export interface UseFormFieldProps<TValue extends PrimitiveValue> {
+export interface UseFormFieldProps<
+  TValue extends PrimitiveValue,
+  TRef extends HTMLElement,
+> {
   value: TValue;
   onChange: (value: TValue) => void;
   onBlur: () => void;
-  ref: RefObject<HTMLInputElement>;
+  ref: RefObject<TRef>;
   hasError: boolean;
   errorCode?: string;
   errorText?: string;
@@ -58,12 +62,13 @@ export interface UseFormFieldProps<TValue extends PrimitiveValue> {
 export function useFormField<
   TValue extends PrimitiveValue,
   TErrorMessageKeys extends GenericErrorMessageKeys = undefined,
+  TRef extends HTMLElement = HTMLInputElement,
 >(
-  options: UseFormFieldOptions<TValue, TErrorMessageKeys>,
-): UseFormFieldProps<TValue> {
+  options: UseFormFieldOptions<TValue, TErrorMessageKeys, TRef>,
+): UseFormFieldProps<TValue, TRef> {
   const [field, setField] = useAtom(options.atom);
   const [wasBlurred, setWasBlurred] = useState(false);
-  const inputRef = useRef<HTMLInputElement>(null);
+  const inputRef = useRef<TRef>(null);
   const [initialized, setInitialized] = useState(false);
 
   useEffect(() => {
@@ -71,15 +76,15 @@ export function useFormField<
     setInitialized(true);
     if (options.initialValue && !field.value) {
       // TODO: handle case where ref is actually null (hasn't been set)
-      setField(options.initialValue, inputRef as RefObject<HTMLInputElement>);
+      setField(options.initialValue, inputRef as RefObject<TRef>);
     } else {
-      setField(NO_VALUE, inputRef as RefObject<HTMLInputElement>);
+      setField(NO_VALUE, inputRef as RefObject<TRef>);
     }
   }, [field.value, initialized, options.initialValue, setField]);
 
   const handleChange = useCallback(
     (value: TValue) => {
-      setField(value, inputRef as RefObject<HTMLInputElement>);
+      setField(value, inputRef as RefObject<TRef>);
       options.onChange?.(value);
     },
     [setField, options],
@@ -107,7 +112,7 @@ export function useFormField<
     value: field.value,
     onChange: handleChange,
     onBlur: handleBlur,
-    ref: inputRef as RefObject<HTMLInputElement>,
+    ref: inputRef as RefObject<TRef>,
     hasError: showError,
     errorCode: field.error,
     errorText:

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -10,7 +10,8 @@
     "skipLibCheck": true,
     "sourceMap": true,
     "strict": true,
-    "target": "ES2022"
+    "target": "ES2022",
+    "jsx": "react-jsx"
   },
   "include": ["src"]
 }

--- a/vitest.config.ts
+++ b/vitest.config.ts
@@ -8,7 +8,7 @@ export default defineConfig({
       include: ["src"],
       reporter: ["html", "lcov"],
     },
-    exclude: ["lib", "node_modules"],
+    exclude: ["docs", "lib", "node_modules"],
     setupFiles: ["console-fail-test/setup"],
   },
 });


### PR DESCRIPTION
<!-- 👋 Hi, thanks for sending a PR to jotai-advanced-forms! 💖.
Please fill out all fields below and make sure each item is true and [x] checked.
Otherwise we may not be able to review your PR. -->

## PR Checklist

- [x] Addresses an existing open issue: fixes #000
- [x] That issue was marked as [`status: accepting prs`](https://github.com/omnidan/jotai-advanced-forms/issues?q=is%3Aopen+is%3Aissue+label%3A%22status%3A+accepting+prs%22)
- [x] Steps in [CONTRIBUTING.md](https://github.com/omnidan/jotai-advanced-forms/blob/main/.github/CONTRIBUTING.md) were taken

## Overview

<!-- Description of what is changed and how the code change does that. -->
This PR adds support to pass a ref type as generic to the `formFieldAtom` and `formFieldAtomFamily` functions.

This is needed to support different input fields like a textarea:

```ts
const { formFieldAtom } = createForm();

const atom = formFieldAtom<string, "required", HTMLTextAreaElement>({
  initialState: "",
  validate: (value) => {
    if (value.length === 0) return "required";
  },
});
```

I also added two unit tests to test the ref, which will implicitly test the ref type as well.

In addition I fixed:
* the eslint config (typescript-eslint plugin could not be found in the additional rules)
* the format script (changes were not written to file)