### PR TITLE
Remove TValue restriction for atoms

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "jotai-advanced-forms",
-  "version": "0.1.4",
+  "version": "0.1.5",
   "description": "📋 collection of atoms, utility functions and hooks to easily create forms with jotai",
   "repository": {
     "type": "git",

--- a/src/form.test.tsx
+++ b/src/form.test.tsx
@@ -315,8 +315,6 @@ describe("formAtom", () => {
       [firstFieldAtom, secondFieldAtom],
     );
 
-    // FIXME: these types don't match because we use `any` in some places,
-    //        but it expects a PrimitiveValue
     const formAtom = internalFormAtom(formStateAtom, formFieldAtoms);
 
     const { result } = renderHook(() => useAtom(firstFieldAtom));
@@ -356,8 +354,6 @@ describe("formAtom", () => {
       [firstFieldAtom, secondFieldAtom],
     );
 
-    // FIXME: these types don't match because we use `any` in some places,
-    //        but it expects a PrimitiveValue
     const formAtom = internalFormAtom(formStateAtom, formFieldAtoms);
 
     const { result } = renderHook(() => useAtom(firstFieldAtom));
@@ -1080,7 +1076,7 @@ describe("different ref types", () => {
   test("validate an atom with initialState null that is set to a string", async () => {
     const { formFieldAtom, useForm } = createForm();
 
-    // set initialState to null and validate it
+    // set initialState to null and define validation
     const atom = formFieldAtom<string | null, "required">({
       initialState: null,
       validate: (value) => {
@@ -1088,6 +1084,7 @@ describe("different ref types", () => {
       },
     });
 
+    // define form
     const {
       result: {
         current: { submitForm },
@@ -1100,13 +1097,19 @@ describe("different ref types", () => {
       }),
     );
 
-    // set value to a string
+    // set value from null to a string
     const { result: fieldResult } = renderHook(() => useAtom(atom));
     const [_, setValue] = fieldResult.current;
     act(() => {
       setValue("test value");
     });
 
+    // submit form to trigger validation
+    await waitFor(() => {
+      submitForm();
+    });
+
+    // fetch result from form field
     const {
       result: { current },
     } = renderHook(() =>
@@ -1117,10 +1120,6 @@ describe("different ref types", () => {
         },
       }),
     );
-
-    await waitFor(() => {
-      submitForm();
-    });
 
     expect(current.hasError).toBe(false);
     expect(current.errorCode).toBeUndefined();

--- a/src/form.test.tsx
+++ b/src/form.test.tsx
@@ -15,7 +15,7 @@ import {
 import { useFormField } from "./useFormField.js";
 
 describe("formFieldAtom", () => {
-  test("value should initially be set to initialValue", () => {
+  test("value should initially be set to initialValue (empty string)", () => {
     const formStateAtom = internalFormStateAtom();
     const formFieldAtom = internalFormFieldAtom(formStateAtom, {
       initialState: "",
@@ -24,6 +24,17 @@ describe("formFieldAtom", () => {
     const { result } = renderHook(() => useAtom(formFieldAtom));
     const [{ value }] = result.current;
     expect(value).toBe("");
+  });
+
+  test("value should initially be set to initialValue (null)", () => {
+    const formStateAtom = internalFormStateAtom();
+    const formFieldAtom = internalFormFieldAtom(formStateAtom, {
+      initialState: null,
+    });
+
+    const { result } = renderHook(() => useAtom(formFieldAtom));
+    const [{ value }] = result.current;
+    expect(value).toBe(null);
   });
 
   test("setting atom should set value", () => {
@@ -1064,5 +1075,81 @@ describe("different ref types", () => {
     render(<textarea ref={ref} />);
 
     expect(ref.current.tagName).toBe("TEXTAREA");
+  });
+
+  test("validate an atom with initialState null that is set to a string", async () => {
+    const { formFieldAtom, useForm } = createForm();
+
+    // set initialState to null and validate it
+    const atom = formFieldAtom<string | null, "required">({
+      initialState: null,
+      validate: (value) => {
+        if (value === null || value.length === 0) return "required";
+      },
+    });
+
+    const {
+      result: {
+        current: { submitForm },
+      },
+    } = renderHook(() =>
+      useForm({
+        onValid: () => {
+          /* do nothing */
+        },
+      }),
+    );
+
+    // set value to a string
+    const { result: fieldResult } = renderHook(() => useAtom(atom));
+    const [_, setValue] = fieldResult.current;
+    act(() => {
+      setValue("test value");
+    });
+
+    const {
+      result: { current },
+    } = renderHook(() =>
+      useFormField({
+        atom,
+        errors: {
+          required: "Please fill out this field.",
+        },
+      }),
+    );
+
+    await waitFor(() => {
+      submitForm();
+    });
+
+    expect(current.hasError).toBe(false);
+    expect(current.errorCode).toBeUndefined();
+    expect(current.value).toBe("test value");
+  });
+
+  test("validate an atom with a file object array", () => {
+    const { formFieldAtom } = createForm();
+
+    const atom = formFieldAtom<File[], "required">({
+      initialState: [new File(["A text file"], "filename.txt")],
+      validate: (value) => {
+        if (value.length === 0) return "required";
+      },
+    });
+
+    const {
+      result: { current },
+    } = renderHook(() =>
+      useFormField({
+        atom,
+        errors: {
+          required: "Please upload at least one file.",
+        },
+      }),
+    );
+
+    expect(current.hasError).toBe(false);
+    expect(current.value).toBeInstanceOf(Array);
+    expect(current.value[0]).toBeInstanceOf(File);
   });
 });

--- a/src/form.test.tsx
+++ b/src/form.test.tsx
@@ -306,7 +306,6 @@ describe("formAtom", () => {
 
     // FIXME: these types don't match because we use `any` in some places,
     //        but it expects a PrimitiveValue
-    // eslint-disable-next-line @typescript-eslint/no-unsafe-argument
     const formAtom = internalFormAtom(formStateAtom, formFieldAtoms);
 
     const { result } = renderHook(() => useAtom(firstFieldAtom));
@@ -348,7 +347,6 @@ describe("formAtom", () => {
 
     // FIXME: these types don't match because we use `any` in some places,
     //        but it expects a PrimitiveValue
-    // eslint-disable-next-line @typescript-eslint/no-unsafe-argument
     const formAtom = internalFormAtom(formStateAtom, formFieldAtoms);
 
     const { result } = renderHook(() => useAtom(firstFieldAtom));

--- a/src/form.ts
+++ b/src/form.ts
@@ -23,7 +23,7 @@ export type JotaiCallback<Param, AtomType> = (event: {
 export type AnyFormFieldAtom = FormFieldAtom<any, any, any>;
 
 export type PrimitiveParam = string;
-export type AnyValue = unknown;
+export type UnknownValue = unknown;
 
 export type GenericErrorMessageKeys = string | undefined;
 
@@ -113,7 +113,10 @@ export interface MultiFormField<
 
 export interface Form extends FormState {
   isValid: boolean;
-  focusableFormFieldsWithError: FormField<AnyValue, GenericErrorMessageKeys>[];
+  focusableFormFieldsWithError: FormField<
+    UnknownValue,
+    GenericErrorMessageKeys
+  >[];
 }
 
 export type FormAtomType = WritableAtom<Form, Partial<FormState>[], void>;
@@ -243,14 +246,16 @@ export function internalFormFieldAtomFamily<
  */
 export function internalFormAtom(
   formStateAtom: PrimitiveAtom<FormState>,
-  formFieldAtoms: Set<FormFieldAtom<AnyValue, GenericErrorMessageKeys>>,
+  formFieldAtoms: Set<FormFieldAtom<UnknownValue, GenericErrorMessageKeys>>,
 ): FormAtomType {
   const formAtom = atom(
     (get) => {
       const res = {
         ...get(formStateAtom),
         isValid: Array.from(formFieldAtoms.values()).every(
-          (formFieldAtom: FormFieldAtom<AnyValue, GenericErrorMessageKeys>) => {
+          (
+            formFieldAtom: FormFieldAtom<UnknownValue, GenericErrorMessageKeys>,
+          ) => {
             const { isValid } = get(formFieldAtom);
             return isValid;
           },

--- a/src/form.ts
+++ b/src/form.ts
@@ -23,7 +23,7 @@ export type JotaiCallback<Param, AtomType> = (event: {
 export type AnyFormFieldAtom = FormFieldAtom<any, any, any>;
 
 export type PrimitiveParam = string;
-export type PrimitiveValue = string | number | boolean | Date | undefined;
+export type AnyValue = unknown;
 
 export type GenericErrorMessageKeys = string | undefined;
 
@@ -35,7 +35,7 @@ export interface FormState {
 }
 
 export interface FormField<
-  TValue extends PrimitiveValue,
+  TValue,
   TErrorMessageKeys extends GenericErrorMessageKeys = undefined,
   TRef extends HTMLElement = HTMLInputElement,
 > {
@@ -54,7 +54,7 @@ export type ShouldRemove<Param extends PrimitiveParam> = (
 ) => boolean;
 
 export interface FormFieldAtomOptions<
-  TValue extends PrimitiveValue,
+  TValue,
   TErrorMessageKeys extends GenericErrorMessageKeys = undefined,
 > {
   initialState: TValue;
@@ -64,7 +64,7 @@ export interface FormFieldAtomOptions<
 
 export interface FormFieldAtomFamilyOptions<
   TParam extends PrimitiveParam,
-  TValue extends PrimitiveValue,
+  TValue,
   TErrorMessageKeys extends GenericErrorMessageKeys = undefined,
 > {
   initialState: TValue;
@@ -75,7 +75,7 @@ export interface FormFieldAtomFamilyOptions<
 }
 
 export type FormFieldAtom<
-  TValue extends PrimitiveValue,
+  TValue,
   TErrorMessageKeys extends GenericErrorMessageKeys = undefined,
   TRef extends HTMLElement = HTMLInputElement,
 > = WritableAtom<
@@ -87,7 +87,7 @@ export type FormFieldAtom<
 
 export type FormFieldAtomFamily<
   TParam extends PrimitiveParam,
-  TValue extends PrimitiveValue,
+  TValue,
   TErrorMessageKeys extends GenericErrorMessageKeys = undefined,
   TRef extends HTMLElement = HTMLInputElement,
 > = AtomFamily<
@@ -101,7 +101,7 @@ export type FormFieldAtomFamily<
 >;
 
 export interface MultiFormField<
-  TValue extends PrimitiveValue,
+  TValue,
   TErrorMessageKeys extends GenericErrorMessageKeys = undefined,
   TRef extends HTMLElement = HTMLInputElement,
 > {
@@ -113,10 +113,7 @@ export interface MultiFormField<
 
 export interface Form extends FormState {
   isValid: boolean;
-  focusableFormFieldsWithError: FormField<
-    PrimitiveValue,
-    GenericErrorMessageKeys
-  >[];
+  focusableFormFieldsWithError: FormField<AnyValue, GenericErrorMessageKeys>[];
 }
 
 export type FormAtomType = WritableAtom<Form, Partial<FormState>[], void>;
@@ -156,7 +153,7 @@ export function internalFormStateAtom(): PrimitiveAtom<FormState> {
  * or not depending on the form state (already submitted)
  */
 export function internalFormFieldAtom<
-  TValue extends PrimitiveValue,
+  TValue,
   TErrorMessageKeys extends GenericErrorMessageKeys = undefined,
   TRef extends HTMLElement = HTMLInputElement,
 >(
@@ -216,7 +213,7 @@ export function internalFormFieldAtom<
 
 export function internalFormFieldAtomFamily<
   TParam extends PrimitiveParam,
-  TValue extends PrimitiveValue,
+  TValue,
   TErrorMessageKeys extends GenericErrorMessageKeys = undefined,
   TRef extends HTMLElement = HTMLInputElement,
 >(
@@ -246,19 +243,14 @@ export function internalFormFieldAtomFamily<
  */
 export function internalFormAtom(
   formStateAtom: PrimitiveAtom<FormState>,
-  formFieldAtoms: Set<FormFieldAtom<PrimitiveValue, GenericErrorMessageKeys>>,
+  formFieldAtoms: Set<FormFieldAtom<AnyValue, GenericErrorMessageKeys>>,
 ): FormAtomType {
   const formAtom = atom(
     (get) => {
       const res = {
         ...get(formStateAtom),
         isValid: Array.from(formFieldAtoms.values()).every(
-          (
-            formFieldAtom: FormFieldAtom<
-              PrimitiveValue,
-              GenericErrorMessageKeys
-            >,
-          ) => {
+          (formFieldAtom: FormFieldAtom<AnyValue, GenericErrorMessageKeys>) => {
             const { isValid } = get(formFieldAtom);
             return isValid;
           },
@@ -410,7 +402,7 @@ export function internalCreateForm() {
 
   // atom creator function for a single form field
   function formFieldAtom<
-    TValue extends PrimitiveValue,
+    TValue,
     TErrorMessageKeys extends GenericErrorMessageKeys = undefined,
     TRef extends HTMLElement = HTMLInputElement,
   >(
@@ -428,7 +420,7 @@ export function internalCreateForm() {
   // atom creator function for form field families
   function formFieldAtomFamily<
     TParam extends PrimitiveParam,
-    TValue extends PrimitiveValue,
+    TValue,
     TErrorMessageKeys extends GenericErrorMessageKeys = undefined,
     TRef extends HTMLElement = HTMLInputElement,
   >(
@@ -584,7 +576,7 @@ export function internalCreateForm() {
    * first names.
    */
   function multiFormField<
-    TValue extends PrimitiveValue,
+    TValue,
     TErrorMessageKeys extends GenericErrorMessageKeys = undefined,
     TRef extends HTMLElement = HTMLInputElement,
   >(

--- a/src/useFormField.ts
+++ b/src/useFormField.ts
@@ -7,7 +7,6 @@ import {
   type RefObject,
 } from "react";
 import {
-  type PrimitiveValue,
   type FormFieldAtom,
   type GenericErrorMessageKeys,
   NO_VALUE,
@@ -18,7 +17,7 @@ import type {
 } from "./formErrorMessages.js";
 
 export type UseFormFieldOptions<
-  TValue extends PrimitiveValue,
+  TValue,
   TErrorMessageKeys extends GenericErrorMessageKeys,
   TRef extends HTMLElement = HTMLInputElement,
 > = {
@@ -46,10 +45,7 @@ export type UseFormFieldOptions<
   DefaultErrorMessageKeys
 >;
 
-export interface UseFormFieldProps<
-  TValue extends PrimitiveValue,
-  TRef extends HTMLElement,
-> {
+export interface UseFormFieldProps<TValue, TRef extends HTMLElement> {
   value: TValue;
   onChange: (value: TValue) => void;
   onBlur: () => void;
@@ -60,7 +56,7 @@ export interface UseFormFieldProps<
 }
 
 export function useFormField<
-  TValue extends PrimitiveValue,
+  TValue,
   TErrorMessageKeys extends GenericErrorMessageKeys = undefined,
   TRef extends HTMLElement = HTMLInputElement,
 >(

--- a/src/useMultiFormField.ts
+++ b/src/useMultiFormField.ts
@@ -3,11 +3,10 @@ import type {
   FormFieldAtomFamily,
   GenericErrorMessageKeys,
   MultiFormField,
-  PrimitiveValue,
 } from "./form.js";
 
 export interface UseMultiFormFieldProps<
-  TValue extends PrimitiveValue,
+  TValue,
   TErrorMessageKeys extends GenericErrorMessageKeys = undefined,
 > {
   atomFamily: FormFieldAtomFamily<string, TValue, TErrorMessageKeys>;
@@ -17,7 +16,7 @@ export interface UseMultiFormFieldProps<
 }
 
 export type UseMultiFormFieldOptions<
-  TValue extends PrimitiveValue,
+  TValue,
   TErrorMessageKeys extends GenericErrorMessageKeys = undefined,
 > = MultiFormField<TValue, TErrorMessageKeys>;
 
@@ -27,7 +26,7 @@ export type UseMultiFormFieldOptions<
  * first names.
  */
 export function useMultiFormField<
-  TValue extends PrimitiveValue,
+  TValue,
   TErrorMessageKeys extends GenericErrorMessageKeys = undefined,
 >({
   atomFamily,


### PR DESCRIPTION
<!-- 👋 Hi, thanks for sending a PR to jotai-advanced-forms! 💖.
Please fill out all fields below and make sure each item is true and [x] checked.
Otherwise we may not be able to review your PR. -->

## Overview

<!-- Description of what is changed and how the code change does that. -->
Because you already implemented a NO_VALUE symbol, we can completely remove the restriction of TValue for atoms.

Examples why this is important:
* some libraries handle undefined or cleared values with null (for example Hero UI's Autocomplete)
* support other date types (Hero UI uses CalendarDate from @internationalized/date)
* support File object to handle file uploads

To avoid having to support all of these different cases, I think we can just get rid of any restriction.